### PR TITLE
feat: add image resolution control in Image Marquee

### DIFF
--- a/base.php
+++ b/base.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) exit;
 final class Base
 {
     private static $_instance = null;
-    const VERSION = '3.9.25';
+    const VERSION = '3.9.26';
 
     public function __construct()
     {

--- a/includes/widget.php
+++ b/includes/widget.php
@@ -10,7 +10,7 @@ final class Marquee
 {
 	use Deensimcpro_Promo;
 
-	const VERSION = '3.9.25';
+	const VERSION = '3.9.26';
 	const MINIMUM_ELEMENTOR_VERSION = '3.5.0';
 	const MINIMUM_PHP_VERSION = '7.4';
 

--- a/includes/widgets/class-deensimc-image-marquee.php
+++ b/includes/widgets/class-deensimc-image-marquee.php
@@ -6,7 +6,7 @@ if (! defined('ABSPATH')) {
 
 // Elementor Classes
 use \Elementor\Widget_Base;
-use Elementor\Group_Control_Image_Size;
+use \Elementor\Group_Control_Image_Size;
 
 /**
  * Class Deensimc_Image_Marquee

--- a/includes/widgets/class-deensimc-image-marquee.php
+++ b/includes/widgets/class-deensimc-image-marquee.php
@@ -6,6 +6,7 @@ if (! defined('ABSPATH')) {
 
 // Elementor Classes
 use \Elementor\Widget_Base;
+use Elementor\Group_Control_Image_Size;
 
 /**
  * Class Deensimc_Image_Marquee
@@ -109,7 +110,28 @@ class Deensimc_Image_Marquee extends Widget_Base
 		}
 
 		foreach ($images as $image) {
-			if (empty($image['url']) || !preg_match('/\.(jpe?g|png|gif|webp|avif|bmp|svg)$/i', $image['url'])) {
+			if (empty($image['url'])) {
+				continue;
+			}
+
+			$image_id = !empty($image['id']) ? absint($image['id']) : 0;
+			$is_svg   = (bool) preg_match('/\.svg(\?.*)?$/i', $image['url']);
+
+			$image_url = $image['url'];
+
+			if ($image_id && ! $is_svg) {
+				$sized = Group_Control_Image_Size::get_attachment_image_src(
+					$image_id,
+					'deensimc_image_marquee',
+					$settings
+				);
+
+				if (!empty($sized)) {
+					$image_url = $sized;
+				}
+			}
+
+			if (!preg_match('/\.(jpe?g|png|gif|webp|avif|bmp|svg)(\?.*)?$/i', $image_url)) {
 				continue;
 			}
 			$is_dup = !empty($image['_is_dup']);
@@ -117,7 +139,7 @@ class Deensimc_Image_Marquee extends Widget_Base
 
 			if ($link_type !== 'none') {
 				if ($link_type === 'file') {
-					echo '<a data-elementor-open-lightbox="' . esc_attr($open_lightbox) . '" href="' . esc_url($image['url']) . '"' . ($is_dup ? ' aria-hidden="true" tabindex="-1"' : '') . '>';
+					echo '<a data-elementor-open-lightbox="' . esc_attr($open_lightbox) . '" href="' . esc_url($image_url) . '"' . ($is_dup ? ' aria-hidden="true" tabindex="-1"' : '') . '>';
 				} elseif ($link_type === 'custom') { ?>
 					<a <?php $this->print_render_attribute_string('deensimc_link'); ?> aria-hidden="<?php echo esc_attr($is_dup ? 'true' : 'false') ?>" tabindex="<?php echo esc_attr($is_dup ? '-1' : '') ?>">
 			<?php
@@ -125,7 +147,7 @@ class Deensimc_Image_Marquee extends Widget_Base
 			}
 
 			echo '<figure class="deensimc-img-wrapper"' . ($is_dup ? ' aria-hidden="true"' : '') . '>';
-			echo '<div class="deensimc-img"><img class="deensimc-marquee-image" src="' . esc_url($image['url']) . '" ' . esc_html($lazy_load_attr) . ' alt="' . esc_attr($alt) . '"></div>';
+			echo '<div class="deensimc-img"><img class="deensimc-marquee-image" src="' . esc_url($image_url) . '" ' . esc_html($lazy_load_attr) . ' alt="' . esc_attr($alt) . '"></div>';
 			echo '<figcaption class="deensimc-image-marquee-caption">'
 				. esc_html($this->deensimc_get_caption($image, $settings['deensimc_caption_type']))
 				. '</figcaption>';

--- a/includes/widgets/class-deensimc-image-marquee.php
+++ b/includes/widgets/class-deensimc-image-marquee.php
@@ -119,7 +119,7 @@ class Deensimc_Image_Marquee extends Widget_Base
 
 			$image_url = $image['url'];
 
-			if ($image_id && ! $is_svg) {
+			if ($image_id && !$is_svg) {
 				$sized = Group_Control_Image_Size::get_attachment_image_src(
 					$image_id,
 					'deensimc_image_marquee',

--- a/includes/widgets/traits/image-marquee/content-image.php
+++ b/includes/widgets/traits/image-marquee/content-image.php
@@ -7,7 +7,7 @@ if (! defined('ABSPATH')) {
 // Elementor Classes
 use \Elementor\Controls_Manager;
 use \Elementor\Utils;
-use Elementor\Group_Control_Image_Size;
+use \Elementor\Group_Control_Image_Size;
 
 trait Deensimc_Image_Marquee_Content_Image
 {

--- a/includes/widgets/traits/image-marquee/content-image.php
+++ b/includes/widgets/traits/image-marquee/content-image.php
@@ -7,6 +7,7 @@ if (! defined('ABSPATH')) {
 // Elementor Classes
 use \Elementor\Controls_Manager;
 use \Elementor\Utils;
+use Elementor\Group_Control_Image_Size;
 
 trait Deensimc_Image_Marquee_Content_Image
 {
@@ -42,6 +43,14 @@ trait Deensimc_Image_Marquee_Content_Image
 				'type' => Controls_Manager::RAW_HTML,
 				'raw' => '<strong>💡 Tip:</strong> For best performance, use a maximum of <strong>20 images</strong>.',
 				'content_classes' => 'elementor-panel-alert elementor-panel-alert-info',
+			]
+		);
+
+		$this->add_group_control(
+			Group_Control_Image_Size::get_type(),
+			[
+				'name' => 'deensimc_image_marquee',
+				'default' => 'full',
 			]
 		);
 

--- a/marquee-addons-for-elementor.php
+++ b/marquee-addons-for-elementor.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Marquee Addons for Elementor - Essential Motion Widgets & Templates
  * Description: Marquee Addons an Elementor addon to create smooth, endless marquee carousels, showcases images, logos, or content with dynamic movement to engage visitors. It also allows you to create image accordions, stacked sliders, and text marquees.
- * Version: 3.9.25
+ * Version: 3.9.26
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Elementor tested up to: 3.35.3
@@ -24,7 +24,7 @@ define('DEENSIMC__DIR__', __DIR__);
 define('DEENSIMC_URL', plugins_url('/', DEENSIMC__FILE__));
 define('DEENSIMC_PATH', plugin_dir_path(__FILE__));
 define('DEENSIMC_ASSETS_URL', DEENSIMC_URL . 'assets/');
-define('DEENSIMC_VERSION', '3.9.25');
+define('DEENSIMC_VERSION', '3.9.26');
 
 function deensimc_load_plugin_data(): void
 {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: debuggersstudio
 Tags: elementor, text marquee, image marquee, video marquee, elementor addons
 Requires at least: 5.8
 Tested up to: 6.9
-Stable tag: 3.9.25
+Stable tag: 3.9.26
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -264,6 +264,9 @@ The developers release regular updates to improve features, fix bugs, and ensure
 First, ensure that you've activated the plugin correctly. If the issue persists, try clearing your browser cache or updating your Elementor plugin. If the problem continues, you can reach out to the support team for assistance.
 
 == Changelog ==
+
+= 3.9.26 - 2026-02-22 =
+- New: Added Image Resolution option in the Image Marquee widget.
 
 = 3.9.25 - 2026-02-19 =
 - New: Added SVG support in the Image Marquee widget.


### PR DESCRIPTION
- Add Elementor Image Size (thumbnail/medium/large/custom) option for gallery images
- Render Image Marquee using selected attachment size with fallback to original URL
- Keep SVGs unscaled and validate supported image formats
- Use resolved image URL for both image src and lightbox link