### PR TITLE
fix: Update Product Carousel demo/doc links and bump to 3.9.27

### DIFF
--- a/base.php
+++ b/base.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) exit;
 final class Base
 {
     private static $_instance = null;
-    const VERSION = '3.9.26';
+    const VERSION = '3.9.27';
 
     public function __construct()
     {

--- a/includes/widget.php
+++ b/includes/widget.php
@@ -10,7 +10,7 @@ final class Marquee
 {
 	use Deensimcpro_Promo;
 
-	const VERSION = '3.9.26';
+	const VERSION = '3.9.27';
 	const MINIMUM_ELEMENTOR_VERSION = '3.5.0';
 	const MINIMUM_PHP_VERSION = '7.4';
 

--- a/marquee-addons-for-elementor.php
+++ b/marquee-addons-for-elementor.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Marquee Addons for Elementor - Essential Motion Widgets & Templates
  * Description: Marquee Addons an Elementor addon to create smooth, endless marquee carousels, showcases images, logos, or content with dynamic movement to engage visitors. It also allows you to create image accordions, stacked sliders, and text marquees.
- * Version: 3.9.26
+ * Version: 3.9.27
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Elementor tested up to: 3.35.3
@@ -24,7 +24,7 @@ define('DEENSIMC__DIR__', __DIR__);
 define('DEENSIMC_URL', plugins_url('/', DEENSIMC__FILE__));
 define('DEENSIMC_PATH', plugin_dir_path(__FILE__));
 define('DEENSIMC_ASSETS_URL', DEENSIMC_URL . 'assets/');
-define('DEENSIMC_VERSION', '3.9.26');
+define('DEENSIMC_VERSION', '3.9.27');
 
 function deensimc_load_plugin_data(): void
 {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: debuggersstudio
 Tags: elementor, text marquee, image marquee, video marquee, elementor addons
 Requires at least: 5.8
 Tested up to: 6.9
-Stable tag: 3.9.26
+Stable tag: 3.9.27
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -264,6 +264,9 @@ The developers release regular updates to improve features, fix bugs, and ensure
 First, ensure that you've activated the plugin correctly. If the issue persists, try clearing your browser cache or updating your Elementor plugin. If the problem continues, you can reach out to the support team for assistance.
 
 == Changelog ==
+
+= 3.9.27 - 2026-02-26 =
+- New: Updated Product Carousel demo and documentation links.
 
 = 3.9.26 - 2026-02-22 =
 - New: Added Image Resolution option in the Image Marquee widget.

--- a/widget-manifest.php
+++ b/widget-manifest.php
@@ -260,7 +260,7 @@ $pro_widgets = [
         'title'  => __('Product Carousel', 'marquee-addons-for-elementor'),
         'icon'   => 'deensimcpro-product-carousel-icon eicon-deensimc-pro',
         'is_pro' => true,
-        'demo'   => 'https://marqueeaddons.com/pricing',
+        'demo'   => 'https://marqueeaddons.com/product-marquee/#product-carousel-demo',
         'doc'   => 'https://marqueeaddons.com/how-to-create-the-product-carousel-in-elementor/',
         'pro_url' => 'https://marqueeaddons.com/pricing/',
     ],

--- a/widget-manifest.php
+++ b/widget-manifest.php
@@ -261,7 +261,7 @@ $pro_widgets = [
         'icon'   => 'deensimcpro-product-carousel-icon eicon-deensimc-pro',
         'is_pro' => true,
         'demo'   => 'https://marqueeaddons.com/pricing',
-        'doc'   => 'https://marqueeaddons.com/how-to-use-the-product-marquee-in-elementor/',
+        'doc'   => 'https://marqueeaddons.com/how-to-create-the-product-carousel-in-elementor/',
         'pro_url' => 'https://marqueeaddons.com/pricing/',
     ],
     'deensimcpro-sticky-cards' => [


### PR DESCRIPTION

Updated Product Carousel demo URL to the correct section anchor
Updated Product Carousel documentation URL
Bumped plugin version to 3.9.27 and updated readme stable tag + changelog