### PR TITLE
chore: bump version to 3.9.46 and update changelog

### DIFF
--- a/base.php
+++ b/base.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) exit;
 final class Base
 {
     private static $_instance = null;
-    const VERSION = '3.9.45';
+    const VERSION = '3.9.46';
 
     public function __construct()
     {

--- a/includes/widget.php
+++ b/includes/widget.php
@@ -10,7 +10,7 @@ final class Marquee
 {
 	use Deensimcpro_Promo;
 
-	const VERSION = '3.9.45';
+	const VERSION = '3.9.46';
 	const MINIMUM_ELEMENTOR_VERSION = '3.5.0';
 	const MINIMUM_PHP_VERSION = '7.4';
 

--- a/marquee-addons-for-elementor.php
+++ b/marquee-addons-for-elementor.php
@@ -4,7 +4,7 @@
  * Plugin Name: Marquee Addons for Elementor - Essential Motion Widgets & Templates
  * Plugin URI: https://marqueeaddons.com/
  * Description: Marquee Addons an Elementor addon to create smooth, endless marquee carousels, showcases images, logos, or content with dynamic movement to engage visitors. It also allows you to create image accordions, stacked sliders, and text marquees.
- * Version: 3.9.45
+ * Version: 3.9.46
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Elementor tested up to: 4.0.1
@@ -25,7 +25,7 @@ define('DEENSIMC__DIR__', __DIR__);
 define('DEENSIMC_URL', plugins_url('/', DEENSIMC__FILE__));
 define('DEENSIMC_PATH', plugin_dir_path(__FILE__));
 define('DEENSIMC_ASSETS_URL', DEENSIMC_URL . 'assets/');
-define('DEENSIMC_VERSION', '3.9.45');
+define('DEENSIMC_VERSION', '3.9.46');
 
 function deensimc_load_plugin_data(): void
 {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: debuggersstudio
 Tags: elementor, text marquee, image marquee, marquee, elementor addons
 Requires at least: 5.8
 Tested up to: 6.9
-Stable tag: 3.9.45
+Stable tag: 3.9.46
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -269,6 +269,9 @@ The developers release regular updates to improve features, fix bugs, and ensure
 First, ensure that you've activated the plugin correctly. If the issue persists, try clearing your browser cache or updating your Elementor plugin. If the problem continues, you can reach out to the support team for assistance.
 
 == Changelog ==
+
+= 3.9.46 - 2026-04-23 =
+- New: Added a new hero template with an angled text marquee.
 
 = 3.9.45 - 2026-04-22 =
 - New: Added One hero template with vertical text marquee.


### PR DESCRIPTION
- Updated version constants across plugin files to 3.9.46
- Updated WordPress plugin header version
- Updated readme stable tag to 3.9.46
- Added changelog entry for new hero template with angled text marquee