### PR TITLE
 Use WordPress attachment alt text in image marquee, update version and changelog

### DIFF
--- a/includes/widgets/class-deensimc-image-marquee.php
+++ b/includes/widgets/class-deensimc-image-marquee.php
@@ -121,7 +121,18 @@ class Deensimc_Image_Marquee extends Widget_Base
 				continue;
 			}
 			$is_dup = !empty($image['_is_dup']);
-			$alt = !empty($image['alt']) ? $image['alt'] : 'Image gallery marquee';
+
+			// Fetch WP Attachment Alt text if available, fallback to custom alt or original string
+			$alt = '';
+			if ($image_id) {
+				$alt = get_post_meta($image_id, '_wp_attachment_image_alt', true);
+			}
+			if (empty($alt) && !empty($image['alt'])) {
+				$alt = $image['alt'];
+			}
+			if (empty($alt)) {
+				$alt = 'Image gallery marquee';
+			}
 
 			if ($link_type !== 'none') {
 				if ($link_type === 'file') {

--- a/marquee-addons-for-elementor.php
+++ b/marquee-addons-for-elementor.php
@@ -7,7 +7,7 @@
  * Version: 3.9.83
  * Requires at least: 5.8
  * Requires PHP: 7.4
- * Elementor tested up to: 4.1.1
+ * Elementor tested up to: 4.2.1
  * Author: Debuggers Studio
  * Author URI: https://debuggersstudio.com
  * Text Domain: marquee-addons-for-elementor

--- a/readme.txt
+++ b/readme.txt
@@ -280,8 +280,8 @@ First, ensure that you've activated the plugin correctly. If the issue persists,
 
 == Changelog ==
 
-= 3.9.83 - 2026-07-16 =
-- New: Added a new review section template featuring testimonials with marquee and drag scrolling.
+= 3.9.83 - 2026-07-30 =
+- Fix: Improved Image Marquee accessibility with better alt text handling.
 
 = 3.9.82 - 2026-07-09 =
 - New: Added a vertical scrolling testimonial review template preview with edge shadow effect.

--- a/templates.json
+++ b/templates.json
@@ -335,14 +335,6 @@
       "preview_url": "https://marqueeaddons.com/marquee-demos/vertical-testimonial-with-edge-shadow/",
       "pricing_url": "https://marqueeaddons.com/pricing/?utm_source=wordpress.org",
       "type": "Review Sections"
-    },
-    {
-      "id": "DemoRS4",
-      "name": "Demo 4",
-      "image_url": "https://marqueeaddons.com/wp-content/uploads/2025/10/Frame-1000005316-min.webp",
-      "preview_url": "https://marqueeaddons.com/marquee-demos/inline-testimonial-scroller/",
-      "pricing_url": "https://marqueeaddons.com/pricing/?utm_source=wordpress.org",
-      "type": "Review Sections"
     }
   ]
 }


### PR DESCRIPTION
- Retrieve alt text from the WordPress attachment metadata
- Fall back to the image's custom alt value when needed
- Use the default "Image gallery marquee" text as a final fallback
- Improve image accessibility and SEO by prioritizing attachment alt text
- Update Elementor compatibility to version 4.2.1
- Revise v3.9.83 changelog with Image Marquee alt text improvement
- Remove the deprecated review section template from templates.json